### PR TITLE
Fix memory leak and severe performance problem

### DIFF
--- a/lib/rack/server_status.rb
+++ b/lib/rack/server_status.rb
@@ -19,18 +19,13 @@ module Rack
     def call(env)
       set_state!('A', env)
 
-      @clean_proc = Remover.new
-      ObjectSpace.define_finalizer(self, @clean_proc)
-
-      if @path && env['PATH_INFO'] == @path
-        res = handle_server_status(env)
-        set_state!('_')
-        return res
+      if env['PATH_INFO'] == @path
+        handle_server_status(env)
+      else
+        @app.call(env)
       end
-
-      res = @app.call(env)
+    ensure
       set_state!('_')
-      return res
     end
 
     private
@@ -132,15 +127,5 @@ EOF
       end
       return [200, {'Content-Type' => 'text/plain'}, [body]]
     end
-
-    class Remover
-      def initialize
-      end
-      def call(*args)
-        set_state!('_')
-      end
-    end
-
   end
-
 end


### PR DESCRIPTION
@SpringMT 

I have fixed memory leak and severe performance problem on Rack::ServerStatus.

The bug was triggered by `ObjectSpace.define_finalizer`.
http://ruby-doc.org/core-2.5.1/ObjectSpace.html#method-c-define_finalizer

Firstly, `ObjectSpace.define_finalizer` is called in `#call`. This means that every time the app receives a request, a new `Remover` object is created and registered as a finalizer.
Secondly, the first argument to `ObjectSpace.define_finalizer` is Rack Middleware `self`. In general usage, Rack Middleware persists until the process is killed. Therefore, registered `Remover` objects are never called nor garbage-collected. This leads to memory leak and severe performance problem.

I have fixed this by using `ensure` to call `set_state!`.

In my local environment, this patch fixes memory leak and improves performance by roughly 1000 times or more. As the total number of requests increases, the performance overhead significantly increases. Firstly, the benchmark yield approx. 1,000 times performance overhead, and secondly the benchmark yield more than 2,000 times performance overhead. (When I tested `100_000`, it yields around 10,000 times performance overhead.

```ruby
require 'rack/server_status'
require 'benchmark'

class Rack::ServerStatus::Improved < Rack::ServerStatus
  def call(env)
    set_state!('A', env)

    if @path == env['PATH_INFO']
      handle_server_status(env)
    else
      @app.call(env)
    end
  ensure
    set_state!('_')
  end
end

simple_app = ->(env) {
  [200, { 'Content-Type' => 'text/plain' }, ["Hello, World"]]
}

app_with_status = Rack::ServerStatus.new(simple_app)
app_with_improved_status = Rack::ServerStatus::Improved.new(simple_app)

NUMBER = 10_000

Benchmark.bmbm(20) do |bm|
  bm.report('default') do
    NUMBER.times { app_with_status.call({}) }
  end

  bm.report('improved') do
    NUMBER.times { app_with_improved_status.call({}) }
  end
end
```

```
$ bundle exec ruby bench.rb
Rehearsal --------------------------------------------------------
default                9.520000   0.060000   9.580000 (  9.670744)
improved               0.010000   0.000000   0.010000 (  0.012461)
----------------------------------------------- total: 9.590000sec

                           user     system      total        real
default               27.600000   0.080000  27.680000 ( 27.762023)
improved               0.010000   0.000000   0.010000 (  0.011982)
```